### PR TITLE
attachments: allow page bundles and single files

### DIFF
--- a/layouts/partials/attachments.html
+++ b/layouts/partials/attachments.html
@@ -1,5 +1,23 @@
 {{ $attachments := .Params.attachments }}
-{{ $pdf_files := .Resources.Match "files/*.pdf" }}
+
+{{ $files := replace $.Page.File.Dir "\\" "/" }}
+{{ if eq $.Page.File.BaseFileName "index" }}
+    {{ $files = printf "%s/files" $files }}
+{{ else }}
+    {{ $files = printf "%s/%s.files" $files $.Page.File.BaseFileName }}
+{{ end }}
+{{ $pdf_files := false }}
+{{ if fileExists $files }}
+    {{ range (readDir (printf "%s/%s" $.Page.Language.ContentDir $files)) }}
+        {{ if findRE "^.*?.pdf" .Name }}
+            {{ if $pdf_files }}
+                {{ $pdf_files = $pdf_files | append .Name }}
+            {{ else }}
+                {{ $pdf_files = slice .Name }}
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}
 
 {{ $header := "Materialien" }}
 {{ with .Scratch.Get "attachments_header" }}
@@ -16,21 +34,21 @@
     <h{{- $level -}}>{{- $header -}}</h{{- $level -}}>
 
     <ul>
+    {{ if reflect.IsSlice $pdf_files }}
     {{ range $pdf_files }}
-        {{ $fileUrl := printf "%s%s" $.Page.File.Dir . }}
-        <li><a href="{{- $fileUrl | absURL | safeURL -}}" target="_blank" rel="nofollow noopener noreferrer"><strong>{{- path.Base .Title -}}</strong></a></li>
+        {{ $fileUrl := printf "%s/%s" $files . }}
+        <li><a href="{{- $fileUrl | absURL | safeURL -}}" target="_blank" rel="nofollow noopener noreferrer">{{- . -}}</a></li>
+    {{ end }}
     {{ end }}
 
     {{ range $attachments }}
         {{ $n := "(annotierter) Foliensatz" }}
-        {{ with index . "name" }}
-            {{ $n = . }}
-        {{ end }}
-
+        {{ with index . "name" }}{{ $n = . }}{{ end }}
         {{ with index . "link" }}
             <li><a href="{{- . | safeURL -}}" target="_blank" rel="nofollow noopener noreferrer">{{- $n -}}</a></li>
         {{ end }}
     {{ end }}
     </ul>
+
 </div>
 {{ end }}


### PR DESCRIPTION
Partial `attachments.html` work now in two ways:

1. Use a YAML parameter
2. Use a special folder `files/`

### YAML

Define a YAML parameter `attachments`: 

```
attachments:
  - link: "url_of_first_attachment"
    name: "name_for_link_in_website"
  - link: "url_of_second_attachment"
```

### Special folder

If your page is a single Markdown file, attachments must be placed in a **folder** named like your page and ending with **`.files/`**.

```
content
    _index.md
    mypage.md
    mypage.files
        attachment.pdf
```

2. If your page is a **page bundle**, attachments must be placed in a nested **`files/`** sub-folder.

```
content
    _index.md
    mypage/
        index.md
        files
            attachment.pdf
```

All `.pdf` files will be collected.
