### PR TITLE
Fix image shotcode

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -3,11 +3,19 @@
 {{ $class := .Get "class" | default "" }}
 {{ $width := .Get "width" | default "auto"}}
 
+{{ if not (hasPrefix $src "http") }}
+    {{ if or (eq $.Page.File.BaseFileName "index") (eq $.Page.File.BaseFileName "_index") }}
+        {{ $src = printf "%s/images/%s" $.Page.File.Dir ($src | path.Base) }}
+    {{ else }}
+        {{ $src = printf "%s/%s.images/%s" $.Page.File.Dir $.Page.File.BaseFileName ($src | path.Base) }}
+    {{ end }}
+    {{ $src = $src | path.Clean | relURL }}
+{{ end }}
+
+{{/* Setting the width of the figure is just a workaround: It should be possible to set the width/height of an image use a style for the img tag. However, hugo seems to gobble this somehow and adds a `style="width: auto; height: auto;"`, which is not quite helpful ... */}}
 {{ with $src }}
-<div class="center" style="width:{{- $width -}}">
-<figure>
+<figure class="center" style="width:{{- $width -}}">
     <img alt="{{- $title -}}" src="{{- $src -}}" class="{{- $class -}}" />
     {{ with $title }}<figcaption><h4>{{- $title -}}</h4></figcaption>{{ end }}
 </figure>
-</div>
 {{ end }}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -10,6 +10,8 @@
         {{ $src = printf "%s/%s.images/%s" $.Page.File.Dir $.Page.File.BaseFileName ($src | path.Base) }}
     {{ end }}
     {{ $src = $src | path.Clean | relURL }}
+{{ else }}
+    {{ $src = $src | safeURL }}
 {{ end }}
 
 {{/* Setting the width of the figure is just a workaround: It should be possible to set the width/height ... */}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -12,7 +12,9 @@
     {{ $src = $src | path.Clean | relURL }}
 {{ end }}
 
-{{/* Setting the width of the figure is just a workaround: It should be possible to set the width/height of an image use a style for the img tag. However, hugo seems to gobble this somehow and adds a `style="width: auto; height: auto;"`, which is not quite helpful ... */}}
+{{/* Setting the width of the figure is just a workaround: It should be possible to set the width/height ... */}}
+{{/* ... of an image using a style for the img tag. However, Hugo (or some of our configuration) seems to ...  */}}
+{{/* ... gobble this somehow and adds a `style="width: auto; height: auto;"`, which is not quite helpful. */}}
 {{ with $src }}
 <figure class="center" style="width:{{- $width -}}">
     <img alt="{{- $title -}}" src="{{- $src -}}" class="{{- $class -}}" />


### PR DESCRIPTION
improve scaling of images using the `img`-shortcode. this should work for page-bundles as well as for single markdown files as well as for landing-pages.

see https://github.com/PM-Dungeon/PM-Lecture/issues/128