### PR TITLE
Shortcode IMG: allow arbitrary folder names

### DIFF
--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -4,12 +4,7 @@
 {{ $width := .Get "width" | default "auto"}}
 
 {{ if not (hasPrefix $src "http") }}
-    {{ if or (eq $.Page.File.BaseFileName "index") (eq $.Page.File.BaseFileName "_index") }}
-        {{ $src = printf "%s/images/%s" $.Page.File.Dir ($src | path.Base) }}
-    {{ else }}
-        {{ $src = printf "%s/%s.images/%s" $.Page.File.Dir $.Page.File.BaseFileName ($src | path.Base) }}
-    {{ end }}
-    {{ $src = $src | path.Clean | relURL }}
+    {{ $src = printf "%s/%s" $.Page.File.Dir $src | path.Clean | relURL }}
 {{ else }}
     {{ $src = $src | safeURL }}
 {{ end }}


### PR DESCRIPTION
the folder name for images has been hardcoded to `./images/` for page bundles and to `./<page>.images/` for individual markdown pages. however, this is really not necessary -- we just need to concatenate the name of the page folder with whatever the user specifies as the image src in the image definition ...

note: we use a quite similar mechanism for attachments. there, however, we have to keep this as we automatically fetch all `.pdf` files from the file folder and therefore have to distinguish the file folders of the different pages.

