### PR TITLE
Button Shortcode: use span and align right

### DIFF
--- a/layouts/shortcodes/button-crossreference.html
+++ b/layouts/shortcodes/button-crossreference.html
@@ -1,5 +1,5 @@
 {{ if .Inner }}
-<a class="btn btn-default btn-crossreference">
-{{ .Inner }}
-</a>
+<span class="btn btn-default btn-crossreference">
+{{ .Inner | markdownify }}
+</span>
 {{ end }}

--- a/layouts/shortcodes/button-crossreference.html
+++ b/layouts/shortcodes/button-crossreference.html
@@ -1,5 +1,7 @@
 {{ if .Inner }}
+<div style="text-align: right;">
 <span class="btn btn-default btn-crossreference">
 {{ .Inner | markdownify }}
 </span>
+</div>
 {{ end }}


### PR DESCRIPTION
We used a non-functional button to add a frame around the content.

Since we also want to enable links in the content, the `<a>...</a>` is replaced by a `<span>...</span>` with the same CSS class. In addition, the "button" is to appear on the right-hand side (as on the slides), so it is additionally wrapped in a `<div style="text-align: right;">...</div>`.