### PR TITLE
[HUGO] Re-Learn-Theme: use orginal 5.x button shortcode 

### DIFF
--- a/layouts/partials/custom-header.html
+++ b/layouts/partials/custom-header.html
@@ -161,10 +161,7 @@ h2 {
 }
 
 .btn-crossreference, .btn-crossreference:hover {
-    cursor: initial !important;
-    color: #333 !important;
-    background-color: #fff !important;
-    border-color: #ccc !important;
+    cursor: initial;
 }
 
 </style>

--- a/layouts/shortcodes/button-crossreference.html
+++ b/layouts/shortcodes/button-crossreference.html
@@ -1,7 +1,7 @@
 {{ if .Inner }}
 <div style="text-align: right;">
-<span class="btn btn-default btn-crossreference">
+<button class="btn-crossreference">
 {{ .Inner | markdownify }}
-</span>
+</button>
 </div>
 {{ end }}

--- a/layouts/shortcodes/button-crossreference.html
+++ b/layouts/shortcodes/button-crossreference.html
@@ -1,7 +1,0 @@
-{{ if .Inner }}
-<div style="text-align: right;">
-<button class="btn-crossreference">
-{{ .Inner | markdownify }}
-</button>
-</div>
-{{ end }}


### PR DESCRIPTION
The "button" shortcode in Hugo-Re-Learn-Theme seems to be improved in 5.x, so let's use the original button (again). The "hugo.lua" pandoc-filter will emit code using the original shortcode.