### PR TITLE
Fix ILIAS 7.x Lern-Modules: append 'index.html' to base-url (we have to use 'ugly' urls)

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,3 +1,3 @@
-<a id="logo" href='{{- .Site.BaseURL -}}'>
+<a id="logo" href='{{- .Site.BaseURL -}}/index.html'>
     <img style="max-width:35%" alt="icon" src='{{- "images/logo.png" | relURL -}}'>
 </a>


### PR DESCRIPTION
Im neuen ILIAS 7.x funktionieren bei den HTML-Lernmodulen die "pretty URLs" nicht mehr und es musste auf "ugly URLs" umgestellt werden.

Allerdings funktioniert das im Logo nicht (mehr). Workaround: Hänge ein "/index.html" an die Base-URL an.