### PR TITLE
Clean Up: Remove superfluous Shortcodes 'challenges' and 'k1' .. 'k4'

### DIFF
--- a/archetypes/README.md
+++ b/archetypes/README.md
@@ -3,11 +3,11 @@
 Use either "page bundles" or "single markdown files" for individual lectures. Lectures are "leafs"
 in the branch hierarchy.
 
-Folders, which do not represent leafs must contain a "landing page", i.e. a file "`_index.md`".
+Folders which do not represent leafs must contain a "landing page", i.e. a file "`_index.md`".
 
 **Do not use underscore ("`_`") nor blanks ("` `") in file names nor in folder names.**
 
-Folders, which contain an empty text file "`.noslides`" will be ignored when generating slides.
+Folders which contain an empty text file "`.noslides`" will be ignored when generating slides.
 
 
 ## Page Bundles
@@ -17,8 +17,6 @@ content/
 |___  _index.md             <= Landing Page
 |___  mypage/               <= Page Bundle for Lecture "mypage"
   |___  index.md            <= Lecture
-  |___  tldr.md             <= TL;DR or Recap
-  |___  outcomes.md         <= Learning Outcomes
   |___  images/
     |___  wuppie.png        <= use "![](images/wuppie.png)"
   |___  files/
@@ -39,6 +37,10 @@ content/
   |___  wuppie.png          <= use "![](mypage.images/wuppie.png)"
 |___  mypage.files/
   |___  annotated.pdf       <= will be included automatically (lecture-bc, lecture-cy)
+|___  images/
+  |___  wuppie.png          <= use "![](images/wuppie.png)"
+|___  files/
+  |___  annotated.pdf       <= will be included automatically (lecture-bc, lecture-cy)
 ```
 
 To reference images in `mypage.md` use `![](mypage.images/wuppie.png)`. This works in GH preview,
@@ -46,3 +48,6 @@ and in slides.
 
 For generated pages we need to transform this to `![](../mypage.images/wuppie.png)` via Lua filter
 or use a (new) custom shortcode. (to be done in https://github.com/PM-Dungeon/PM-Lecture/issues/128)
+
+You could also just use `images/` and/or `files/`. Those folders are reachable from all pages in
+this chapter ...

--- a/layouts/partials/outcomes.html
+++ b/layouts/partials/outcomes.html
@@ -1,11 +1,10 @@
 {{ $outcomes := .Params.outcomes }}
 
-{{ if $outcomes }}
+{{ if (and $outcomes (reflect.IsSlice $outcomes)) }}
+{{/* do not engage unless it's a list: workaround for use in lecture-cy */}}
 <div class="outcomes">
     <h2>Lernziele</h2>
 
-    {{ if reflect.IsSlice $outcomes }}
-    {{/* do not engage unless it's a list: workaround for use in lecture-cy */}}
     <ul>
     {{ range $outcomes }}
         {{ with index . "k1" }}<li>{{ print "(K1) " }}{{ . | $.RenderString }}</li>{{ end }}
@@ -14,7 +13,6 @@
         {{ with index . "k4" }}<li>{{ print "(K4) " }}{{ . | $.RenderString }}</li>{{ end }}
     {{ end }}
     </ul>
-    {{ end }}
 
 </div>
 {{ end }}

--- a/layouts/partials/outcomes.html
+++ b/layouts/partials/outcomes.html
@@ -1,18 +1,13 @@
-{{ $outcomesR := .Resources.Match "outcomes.md" }}
-{{ $outcomesP := .Params.outcomes }}
+{{ $outcomes := .Params.outcomes }}
 
-{{ if (or $outcomesR $outcomesP) }}
+{{ if $outcomes }}
 <div class="outcomes">
     <h2>Lernziele</h2>
 
-    {{ range $outcomesR }}
-        {{ .Content }}
-    {{ end }}
-
-    {{ if reflect.IsSlice $outcomesP }}
+    {{ if reflect.IsSlice $outcomes }}
     {{/* do not engage unless it's a list: workaround for use in lecture-cy */}}
     <ul>
-    {{ range $outcomesP }}
+    {{ range $outcomes }}
         {{ with index . "k1" }}<li>{{ print "(K1) " }}{{ . | $.RenderString }}</li>{{ end }}
         {{ with index . "k2" }}<li>{{ print "(K2) " }}{{ . | $.RenderString }}</li>{{ end }}
         {{ with index . "k3" }}<li>{{ print "(K3) " }}{{ . | $.RenderString }}</li>{{ end }}

--- a/layouts/partials/tldr.html
+++ b/layouts/partials/tldr.html
@@ -1,18 +1,13 @@
-{{ $tldrR := .Resources.Match "tldr.md" }}
-{{ $tldrP := .Params.tldr }}
+{{ $tldr := .Params.tldr }}
 {{ $yt := .Params.youtube }}
 {{ $fh := .Params.fhmedia }}
 {{ $attachments := .Params.attachments }}
 
-{{ if or (or $tldrR $tldrP) (or $attachments (or $yt $fh)) }}
+{{ if (or $tldr (or $attachments (or $yt $fh))) }}
 <div class="tldr">
     <h2>TL;DR</h2>
 
-    {{ range $tldrR }}
-        {{ .Content }}
-    {{ end }}
-
-    {{ with $tldrP }}
+    {{ with $tldr }}
         {{ . | $.RenderString }}
     {{ end }}
 

--- a/layouts/shortcodes/challenges.html
+++ b/layouts/shortcodes/challenges.html
@@ -1,5 +1,0 @@
-{{ if .Inner }}
-<div class="challenges">
-{{ .Inner }}
-</div>
-{{ end }}

--- a/layouts/shortcodes/k1.html
+++ b/layouts/shortcodes/k1.html
@@ -1,4 +1,0 @@
-{{ if .Inner }}
-<h3>Kennen (K1)</h3>
-{{ .Inner }}
-{{ end }}

--- a/layouts/shortcodes/k2.html
+++ b/layouts/shortcodes/k2.html
@@ -1,4 +1,0 @@
-{{ if .Inner }}
-<h3>Verstehen (K2)</h3>
-{{ .Inner }}
-{{ end }}

--- a/layouts/shortcodes/k3.html
+++ b/layouts/shortcodes/k3.html
@@ -1,4 +1,0 @@
-{{ if .Inner }}
-<h3>Anwenden (K3)</h3>
-{{ .Inner }}
-{{ end }}

--- a/layouts/shortcodes/k4.html
+++ b/layouts/shortcodes/k4.html
@@ -1,4 +1,0 @@
-{{ if .Inner }}
-<h3>Analysieren (K4)</h3>
-{{ .Inner }}
-{{ end }}


### PR DESCRIPTION
* `challenges` is superfluous - it just wraps it's content in a div with class 'challenges'. this could (and should) be done directly using pandocs markdown divs ...
* `k1` .. `k4` are not needed anymore since we use a yaml-entry for this
* Remove rendering of `outcomes.md` and/or `tldr.md` (use yaml-entries for this)