### PR TITLE
[Schedule] Drop numbering weeks

### DIFF
--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -26,9 +26,7 @@
         {{ $misc_assignment := index $w "misc_assignment" }}
         <tr>
             <td>
-                {{ printf "%d" (add $i 1) }}
-                <br>
-                {{ printf "(%s)" $week }}
+                {{ printf "%s" $week }}
             </td>
             <td>
             {{ if $datel }}{{- $datel -}}{{ end }}

--- a/layouts/shortcodes/schedule.html
+++ b/layouts/shortcodes/schedule.html
@@ -25,9 +25,7 @@
         {{ $misc_lecture := index $w "misc_lecture" }}
         {{ $misc_assignment := index $w "misc_assignment" }}
         <tr>
-            <td>
-                {{ printf "%s" $week }}
-            </td>
+            <td>{{ printf "%s" $week }}</td>
             <td>
             {{ if $datel }}{{- $datel -}}{{ end }}
             <ul>


### PR DESCRIPTION
Im Shortcode "schedule" zählen wir automatisch die Vorlesungswochen hoch. 

Ursprünglich war das mal dazu gedacht, im dazugehörigen "schedule.yaml" nicht mehr selbst Kalenderwochen oder konkrete Datumsangaben machen zu müssen, die dann mühsam von Jahr zu Jahr aktualisiert werden müssen.

Die Praxis hat gezeigt, dass dies aber trotzdem passiert und auch notwendig ist, damit die Studis eine bessere Orientierung haben. Dabei ist dann aber das automatische Hochzählen der Vorlesungswoche irgendwie überflüssig, und im Fall der Weihnachts-"ferien" stört das sogar (das sind ja dann keine Vorlesungswochen).

Entsprechend wird in diesem PR das automatische Hochzählen der Vorlesungswochen im Shortcode entfernt.