### PR TITLE
[Archetypes] Home-Page: do not show metadata title

### DIFF
--- a/layouts/partials/archetypes/home/article.html
+++ b/layouts/partials/archetypes/home/article.html
@@ -1,0 +1,15 @@
+{{- $page := .page }}
+{{- $content := .content }}
+{{- with $page }}
+<article class="chapter">
+{{ partial "heading-pre.html" . }}{{ partial "heading-post.html" . }}
+
+
+{{ $content | safeHTML }}
+
+
+<footer class="footline">
+{{- partial "content-footer.html" . }}
+</footer>
+</article>
+{{- end }}


### PR DESCRIPTION
The `title` field from metadata will be used also in browser tab and in breadcrumb navigation, so we will want something short here. On the other hand, the title for the home-page should be a more welcome-ish something, so let's use our own h1 header here ...

This add a custom definition for archetype `home` (identical to `chapter`, but omit the `title` field from metadata).