### PR TITLE
[Partial] Logo: use language extension (if present)

### DIFF
--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,0 +1,10 @@
+    {{- $assetBusting := not .Site.Params.disableAssetsBusting }}
+
+    {{ $logo := "images/logo.png" }}
+    {{ if .Site.IsMultiLingual }}
+        {{ with (strings.TrimPrefix "/" .Site.LanguagePrefix) }}
+            {{ $logo = printf "images/logo.%s.png" . }}
+        {{ end }}
+    {{ end }}
+
+    <link href="{{ $logo | relURL }}{{ if $assetBusting }}?{{ now.Unix }}{{ end }}" rel="icon" type="image/png">

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,3 +1,11 @@
+{{ $logo := "images/logo.png" }}
+
+{{ if .Site.IsMultiLingual }}
+    {{ with (strings.TrimPrefix "/" .Site.LanguagePrefix) }}
+        {{ $logo = printf "images/logo.%s.png" . }}
+    {{ end }}
+{{ end }}
+
 <a id="logo" href='{{- .Site.BaseURL -}}/index.html'>
-    <img style="max-width:35%" alt="icon" src='{{- "images/logo.png" | relURL -}}'>
+    <img style="max-width:35%" alt="icon" src='{{- $logo | relURL -}}'>
 </a>


### PR DESCRIPTION
Multi-Lingual: Unterschiedliche Logos je nach Sprache

Baut in Partials/Logo.html eine Sprachweiche ein: Wenn Multi-Lingual aktiv, dann wird der aktuelle Sprach-Prefix als Suffix an den Logo-Dateinamen angefügt: Sprache "ba" => "images/logo.ba.png" (statt wie sonst "images/logo.png").

~~Allerdings wird dadurch das Favicon nicht geändert!~~ Update: Durch Überschreiben von Partials/Favicon.html wird nun auch das "Sprach-angepasste" Logo als Favicon genutzt.

fixes #36 